### PR TITLE
Move to tinted-terminal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tinted-theming/kermit
+* @tinted-theming/kermit-terminal

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,8 +1,6 @@
 name: Update with the latest tinted-theming colorschemes
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 0" # https://crontab.guru/every-week
 
 jobs:
   build-and-commit:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # tinted-kermit-terminal
 
+**Deprecated**: tinted-kermit and all the other Tinted Theming
+terminal template repositories have moved to a single [Tinted
+Terminal](https://github.com/tinted-theming/tinted-terminal) repository.
+
+---
+
 This repository provides themes for the VTE-based [kermit terminal] and
 a simple template that can be used with the [tinted-theming] color
 schemes to generate config files.


### PR DESCRIPTION
As discussed in https://github.com/tinted-theming/home/issues/44#issuecomment-2518520414, this PR adds a deprecation notice and links to [tinted-terminal](https://github.com/tinted-theming/tinted-terminal). @tinted-theming/kermit-terminal  should already have maintainer access for [tinted-terminal](https://github.com/tinted-theming/tinted-terminal). Once this is merged I'll archive this repo.

- Add deprecation notice to README
- Remove cron job